### PR TITLE
80 support fixes

### DIFF
--- a/8.0rev150427/Sitecore.SharedSource.RoleConfigs.Delivery.config
+++ b/8.0rev150427/Sitecore.SharedSource.RoleConfigs.Delivery.config
@@ -316,6 +316,10 @@
       <patch:delete/>
     </csvReader>
     <customHandlers>
+		<!--Disable Sitecore.ExperienceEditor.Speak.Requests.config -->
+		<handler trigger="/-/speak/request/v1/expeditor/">
+			<patch:delete/>
+		</handler>
       <!--Disable Sitecore.Analytics.Reporting.config. ReportDataHandler requests handler removed -->
       <handler trigger="/~/analytics/reports">
         <patch:delete/>
@@ -470,8 +474,8 @@
         <processor type="Sitecore.ExperienceAnalytics.Api.Pipelines.Initialize.WebApiInitializer, Sitecore.ExperienceAnalytics">
           <patch:delete/>
         </processor>
-        <!-- Disable Sitecore.ListManagement.Services.config. RegisterHttpRoutes removed-->
         <processor type="Sitecore.ListManagement.Services.Pipelines.Initialize.RegisterHttpRoutes, Sitecore.ListManagement.Services">
+          <!-- Disable Sitecore.ListManagement.Services.config. RegisterHttpRoutes removed-->
           <patch:delete/>
         </processor>
         <!--Disable Sitecore.PathAnalyzer.config. PathAnalyzer Loader processor removed -->
@@ -676,8 +680,8 @@
       <patch:delete/>
     </ruleEngine>
     <scheduling>
-      <!--Disable Sitecore.ListManagement.config. UnlockContactListsAgent removed -->
       <agent type="Sitecore.ListManagement.Analytics.UnlockContactListsAgent, Sitecore.ListManagement.Analytics">
+        <!--Disable Sitecore.ListManagement.config. UnlockContactListsAgent removed -->
         <patch:delete/>
       </agent>
     </scheduling>
@@ -686,22 +690,8 @@
       <patch:delete/>
     </segmentedListManager>
     <sitecore.experienceeditor.speak.requests>
-      <!-- Disable Sitecore.FXM.Speak.config. Multiple requests removed. -->
-      <request name="ExperienceEditor.FXM.GetRulesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetGoalsEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetAttributesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetClientActionsData">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetElementReplacersData">
-        <patch:delete/>
-      </request>
+		<!-- Disable Sitecore.ExperienceEditor.Speak.Requests, Sitecore.ExperienceExplorer.Speak.Requests.config, Sitecore.ContentTesting, and other configs. Multiple requests removed.-->
+		<patch:delete/>
     </sitecore.experienceeditor.speak.requests>
     <useRepository>
       <!-- Disable Sitecore.ListManagement.config. useRepository removed-->

--- a/8.0rev150621/Sitecore.SharedSource.RoleConfigs.Delivery.config
+++ b/8.0rev150621/Sitecore.SharedSource.RoleConfigs.Delivery.config
@@ -292,6 +292,10 @@
       <patch:delete/>
     </csvReader>
     <customHandlers>
+		<!--Disable Sitecore.ExperienceEditor.Speak.Requests.config -->
+		<handler trigger="/-/speak/request/v1/expeditor/">
+			<patch:delete/>
+		</handler>
       <!--Disable Sitecore.Analytics.Reporting.config. ReportDataHandler requests handler removed -->
       <handler trigger="/~/analytics/reports">
         <patch:delete/>
@@ -460,8 +464,8 @@
         <processor type="Sitecore.ExperienceAnalytics.Api.Pipelines.Initialize.WebApiInitializer, Sitecore.ExperienceAnalytics">
           <patch:delete/>
         </processor>
-        <!-- Disable Sitecore.ListManagement.Services.config. RegisterHttpRoutes removed-->
         <processor type="Sitecore.ListManagement.Services.Pipelines.Initialize.RegisterHttpRoutes, Sitecore.ListManagement.Services">
+          <!-- Disable Sitecore.ListManagement.Services.config. RegisterHttpRoutes removed-->
           <patch:delete/>
         </processor>
         <!--Disable Sitecore.PathAnalyzer.config. PathAnalyzer Loader processor removed -->
@@ -665,8 +669,8 @@
       <patch:delete/>
     </ruleEngine>
     <scheduling>
-      <!--Disable Sitecore.ListManagement.config. UnlockContactListsAgent removed -->
       <agent type="Sitecore.ListManagement.Analytics.UnlockContactListsAgent, Sitecore.ListManagement.Analytics">
+        <!--Disable Sitecore.ListManagement.config. UnlockContactListsAgent removed -->
         <patch:delete/>
       </agent>
     </scheduling>
@@ -675,22 +679,8 @@
       <patch:delete/>
     </segmentedListManager>
     <sitecore.experienceeditor.speak.requests>
-      <!-- Disable Sitecore.FXM.Speak.config. Multiple requests removed. -->
-      <request name="ExperienceEditor.FXM.GetRulesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetGoalsEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetAttributesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetClientActionsData">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetElementReplacersData">
-        <patch:delete/>
-      </request>
+		<!-- Disable Sitecore.ExperienceEditor.Speak.Requests, Sitecore.ExperienceExplorer.Speak.Requests.config, Sitecore.ContentTesting, and other configs. Multiple requests removed.-->
+		<patch:delete/>
     </sitecore.experienceeditor.speak.requests>
     <useRepository>
       <!-- Disable Sitecore.ListManagement.config. useRepository removed-->

--- a/8.0rev150812/Sitecore.SharedSource.RoleConfigs.Delivery.config
+++ b/8.0rev150812/Sitecore.SharedSource.RoleConfigs.Delivery.config
@@ -292,6 +292,10 @@
       <patch:delete/>
     </csvReader>
     <customHandlers>
+		<!--Disable Sitecore.ExperienceEditor.Speak.Requests.config -->
+		<handler trigger="/-/speak/request/v1/expeditor/">
+			<patch:delete/>
+		</handler>
       <!--Disable Sitecore.Analytics.Reporting.config. ReportDataHandler requests handler removed -->
       <handler trigger="/~/analytics/reports">
         <patch:delete/>
@@ -460,8 +464,8 @@
         <processor type="Sitecore.ExperienceAnalytics.Api.Pipelines.Initialize.WebApiInitializer, Sitecore.ExperienceAnalytics">
           <patch:delete/>
         </processor>
-        <!-- Disable Sitecore.ListManagement.Services.config. RegisterHttpRoutes removed-->
         <processor type="Sitecore.ListManagement.Services.Pipelines.Initialize.RegisterHttpRoutes, Sitecore.ListManagement.Services">
+          <!-- Disable Sitecore.ListManagement.Services.config. RegisterHttpRoutes removed-->
           <patch:delete/>
         </processor>
         <!--Disable Sitecore.PathAnalyzer.config. PathAnalyzer Loader processor removed -->
@@ -665,8 +669,8 @@
       <patch:delete/>
     </ruleEngine>
     <scheduling>
-      <!--Disable Sitecore.ListManagement.config. UnlockContactListsAgent removed -->
       <agent type="Sitecore.ListManagement.Analytics.UnlockContactListsAgent, Sitecore.ListManagement.Analytics">
+        <!--Disable Sitecore.ListManagement.config. UnlockContactListsAgent removed -->
         <patch:delete/>
       </agent>
     </scheduling>
@@ -675,22 +679,8 @@
       <patch:delete/>
     </segmentedListManager>
     <sitecore.experienceeditor.speak.requests>
-      <!-- Disable Sitecore.FXM.Speak.config. Multiple requests removed. -->
-      <request name="ExperienceEditor.FXM.GetRulesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetGoalsEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetAttributesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetClientActionsData">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetElementReplacersData">
-        <patch:delete/>
-      </request>
+		<!-- Disable Sitecore.ExperienceEditor.Speak.Requests, Sitecore.ExperienceExplorer.Speak.Requests.config, Sitecore.ContentTesting, and other configs. Multiple requests removed.-->
+		<patch:delete/>
     </sitecore.experienceeditor.speak.requests>
     <useRepository>
       <!-- Disable Sitecore.ListManagement.config. useRepository removed-->

--- a/8.0rev151127/Sitecore.SharedSource.RoleConfigs.Delivery.config
+++ b/8.0rev151127/Sitecore.SharedSource.RoleConfigs.Delivery.config
@@ -292,6 +292,10 @@
       <patch:delete/>
     </csvReader>
     <customHandlers>
+		<!--Disable Sitecore.ExperienceEditor.Speak.Requests.config -->
+		<handler trigger="/-/speak/request/v1/expeditor/">
+			<patch:delete/>
+		</handler>
       <!--Disable Sitecore.Analytics.Reporting.config. ReportDataHandler requests handler removed -->
       <handler trigger="/~/analytics/reports">
         <patch:delete/>
@@ -671,22 +675,8 @@
       <patch:delete/>
     </segmentedListManager>
     <sitecore.experienceeditor.speak.requests>
-      <!-- Disable Sitecore.FXM.Speak.config. Multiple requests removed. -->
-      <request name="ExperienceEditor.FXM.GetRulesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetGoalsEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetAttributesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetClientActionsData">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetElementReplacersData">
-        <patch:delete/>
-      </request>
+		<!-- Disable Sitecore.ExperienceEditor.Speak.Requests, Sitecore.ExperienceExplorer.Speak.Requests.config, Sitecore.ContentTesting, and other configs. Multiple requests removed.-->
+		<patch:delete/>
     </sitecore.experienceeditor.speak.requests>
     <useRepository>
       <!-- Disable Sitecore.ListManagement.config. useRepository removed-->

--- a/8.0rev160115/Sitecore.SharedSource.RoleConfigs.Delivery.config
+++ b/8.0rev160115/Sitecore.SharedSource.RoleConfigs.Delivery.config
@@ -292,6 +292,10 @@
       <patch:delete/>
     </csvReader>
     <customHandlers>
+		<!--Disable Sitecore.ExperienceEditor.Speak.Requests.config -->
+		<handler trigger="/-/speak/request/v1/expeditor/">
+			<patch:delete/>
+		</handler>
       <!--Disable Sitecore.Analytics.Reporting.config. ReportDataHandler requests handler removed -->
       <handler trigger="/~/analytics/reports">
         <patch:delete/>
@@ -671,22 +675,8 @@
       <patch:delete/>
     </segmentedListManager>
     <sitecore.experienceeditor.speak.requests>
-      <!-- Disable Sitecore.FXM.Speak.config. Multiple requests removed. -->
-      <request name="ExperienceEditor.FXM.GetRulesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetGoalsEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetAttributesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetClientActionsData">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetElementReplacersData">
-        <patch:delete/>
-      </request>
+		<!-- Disable Sitecore.ExperienceEditor.Speak.Requests, Sitecore.ExperienceExplorer.Speak.Requests.config, Sitecore.ContentTesting, and other configs. Multiple requests removed.-->
+		<patch:delete/>
     </sitecore.experienceeditor.speak.requests>
     <useRepository>
       <!-- Disable Sitecore.ListManagement.config. useRepository removed-->

--- a/Sitecore.SharedSource.RoleConfigs/Sitecore.SharedSource.RoleConfigs/App_Config/Include/z_FinalConfigs/Sitecore.SharedSource.RoleConfigs.Delivery.config
+++ b/Sitecore.SharedSource.RoleConfigs/Sitecore.SharedSource.RoleConfigs/App_Config/Include/z_FinalConfigs/Sitecore.SharedSource.RoleConfigs.Delivery.config
@@ -292,6 +292,10 @@
       <patch:delete/>
     </csvReader>
     <customHandlers>
+		<!--Disable Sitecore.ExperienceEditor.Speak.Requests.config -->
+		<handler trigger="/-/speak/request/v1/expeditor/">
+			<patch:delete/>
+		</handler>
       <!--Disable Sitecore.Analytics.Reporting.config. ReportDataHandler requests handler removed -->
       <handler trigger="/~/analytics/reports">
         <patch:delete/>
@@ -675,22 +679,8 @@
       <patch:delete/>
     </segmentedListManager>
     <sitecore.experienceeditor.speak.requests>
-      <!-- Disable Sitecore.FXM.Speak.config. Multiple requests removed. -->
-      <request name="ExperienceEditor.FXM.GetRulesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetGoalsEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetAttributesEditorUrl">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetClientActionsData">
-        <patch:delete/>
-      </request>
-      <request name="ExperienceEditor.FXM.GetElementReplacersData">
-        <patch:delete/>
-      </request>
+		<!-- Disable Sitecore.ExperienceEditor.Speak.Requests, Sitecore.ExperienceExplorer.Speak.Requests.config, Sitecore.ContentTesting, and other configs. Multiple requests removed.-->
+		<patch:delete />
     </sitecore.experienceeditor.speak.requests>
     <useRepository>
       <!-- Disable Sitecore.ListManagement.config. useRepository removed-->


### PR DESCRIPTION
Sitecore documentation for 8.0 has been updated to now disable Sitecore.ExperienceEditor.Speak.Requests.config and Sitecore.ExperienceExplorer.Speak.Requests.config on a Content Delivery node.
